### PR TITLE
Increase timeout to handle ident

### DIFF
--- a/aiolip/protocol.py
+++ b/aiolip/protocol.py
@@ -23,7 +23,7 @@ LIP_BUTTON_RELEASE = 4
 
 LIP_KEEP_ALIVE = "?SYSTEM,10"
 
-CONNECT_TIMEOUT = 10
+CONNECT_TIMEOUT = 45  # The bridge can try to do ident which can take up to 30 seconds
 SOCKET_TIMEOUT = 10
 
 LIP_READ_TIMEOUT = 60


### PR DESCRIPTION
The bridge can take up to 30 seconds to do ident. The
connect timeout has been raised to 45 seconds.

Fixes #2